### PR TITLE
Split the Jenkins/Configure seed job in two

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ COPY --chown=jenkins init.groovy.d/scriptApproval.xml /usr/share/jenkins/ref/
 # Disable the setup wizard 
 ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false ${JAVA_OPTS:-}"
 
-ENV BOOTSTRAP_SHARED_LIBRARY_GIT_REPO fr123k/jocker
-ENV BOOTSTRAP_SHARED_LIBRARY_GROOVY_FILE shared-library/pipeline.groovy
+ENV SEED_CONFIGURE_GIT_REPO fr123k/jocker
+ENV SEED_CONFIGURE_GROOVY_FILE shared-library/pipeline.groovy
+
+ENV SEED_JOB_GIT_REPO fr123k/jocker
+ENV SEED_JOB_GROOVY_FILE shared-library/pipeline-jobs.groovy
 
 ENV JENKINS_CLI /var/jenkins_home/war/WEB-INF/jenkins-cli.jar

--- a/dsl/bootstrap.groovy
+++ b/dsl/bootstrap.groovy
@@ -4,6 +4,42 @@ folder('Jenkins') {
     description('Folder containing configuration and seed jobs')
 }
 
+pipelineJob("Jenkins/Setup") {
+    parameters {
+        stringParam('revision_configure', 'origin/master', '')
+        stringParam('revision_jobs', 'origin/master', '')
+    }
+
+    triggers {
+        githubPush()
+    }
+
+    logRotator {
+        numToKeep(50)
+    }
+
+    definition {
+        cps {
+            script("""
+        node ("master") {
+            stage("Configure") {
+                build(job:'Jenkins/Configure', parameters:[
+                    string(name: 'revision', value: params.revision_configure)],
+                    propagate:true,
+                    wait:true)
+            }
+            stage("Jobs") {
+                build(job:'Jenkins/Jobs', parameters:[
+                    string(name: 'revision', value: params.revision_jobs)],
+                    propagate:true,
+                    wait:true)
+            }
+        }
+            """)
+        }
+    }
+}
+
 pipelineJob("Jenkins/Configure") {
     parameters {
         gitParam('revision') {
@@ -26,7 +62,7 @@ pipelineJob("Jenkins/Configure") {
             scm {
                 git {
                     remote {
-                        github("{{ shared-library-git-repo }}", "ssh")
+                        github("{{ seed-configure-git-repo }}", "ssh")
                         credentials("deploy-key-shared-library")
                     }
 
@@ -34,7 +70,42 @@ pipelineJob("Jenkins/Configure") {
                 }
             }
             //shared-library/pipeline.groovy
-            scriptPath('{{ shared-library-groovy-file }}')
+            scriptPath('{{ seed-configure-groovy-file }}')
+        }
+    }
+}
+
+pipelineJob("Jenkins/Jobs") {
+    parameters {
+        gitParam('revision') {
+            type('BRANCH_TAG')
+            sortMode('ASCENDING_SMART')
+            defaultValue('origin/master')
+        }
+    }
+
+    triggers {
+        githubPush()
+    }
+
+    logRotator {
+        numToKeep(50)
+    }
+
+    definition {
+        cpsScm {
+            scm {
+                git {
+                    remote {
+                        github("{{ seed-job-git-repo }}", "ssh")
+                        credentials("deploy-key-shared-library")
+                    }
+
+                    branch('$revision')
+                }
+            }
+            //shared-library/pipeline.groovy
+            scriptPath('{{ seed-job-groovy-file }}')
         }
     }
 }

--- a/init.groovy.d/init.groovy
+++ b/init.groovy.d/init.groovy
@@ -56,17 +56,16 @@ def env = System.getenv()
 
 // Create the configuration pipeline from a jobDSL script
 def jobDslScriptContent = new File('/var/jenkins_home/dsl/bootstrap.groovy').text
-jobDslScriptContent = jobDslScriptContent.replace('{{ shared-library-git-repo }}', env['BOOTSTRAP_SHARED_LIBRARY_GIT_REPO'])
-jobDslScriptContent = jobDslScriptContent.replace('{{ shared-library-groovy-file }}', env['BOOTSTRAP_SHARED_LIBRARY_GROOVY_FILE'])
+jobDslScriptContent = jobDslScriptContent.replace('{{ seed-configure-git-repo }}', env['SEED_CONFIGURE_GIT_REPO'])
+jobDslScriptContent = jobDslScriptContent.replace('{{ seed-configure-groovy-file }}', env['SEED_CONFIGURE_GROOVY_FILE'])
+
+jobDslScriptContent = jobDslScriptContent.replace('{{ seed-job-git-repo }}', env['SEED_JOB_GIT_REPO'])
+jobDslScriptContent = jobDslScriptContent.replace('{{ seed-job-groovy-file }}', env['SEED_JOB_GROOVY_FILE'])
+
 
 def workspace = new File('.')
 def jobManagement = new JenkinsJobManagement(System.out, [:], workspace)
 new DslScriptLoader(jobManagement).runScript(jobDslScriptContent)
-
-// Schdule the Jenkins/Configure job
-// Use the provided SEED_BRANCH environment vairable if specified
-def seedRevision = env['SEED_BRANCH'] ?: "origin/master"
-Jenkins.instance.getItemByFullName("Jenkins/Configure").scheduleBuild2(1, new ParametersAction([ new StringParameterValue("revision", seedRevision)]))
 
 println(Jenkins.instance.getSecurityRealm().getClass().getSimpleName())
 // Disable Wizards
@@ -97,3 +96,8 @@ if(Jenkins.instance.getSecurityRealm().getClass().getSimpleName() == 'None') {
 
     println("SetupWizard Disabled")
 }
+
+// Schdule the Jenkins/Configure job
+// Use the provided SEED_BRANCH environment vairable if specified
+def seedRevision = env['SEED_BRANCH'] ?: "origin/master"
+Jenkins.instance.getItemByFullName("Jenkins/Setup").scheduleBuild2(1, new ParametersAction([ new StringParameterValue("revision_configure", seedRevision), new StringParameterValue("revision_jobs", seedRevision)]))

--- a/plugins.txt
+++ b/plugins.txt
@@ -25,3 +25,6 @@ throttle-concurrents
 
 # mask password
 mask-passwords
+
+# provide build step to pipeline
+pipeline-build-step

--- a/shared-library/config/casc-config/jenkins.yaml
+++ b/shared-library/config/casc-config/jenkins.yaml
@@ -1,6 +1,6 @@
 ---
 jenkins:
-  numExecutors: 1
+  numExecutors: 4
 
   remotingSecurity:
     enabled: true

--- a/shared-library/pipeline-jobs.groovy
+++ b/shared-library/pipeline-jobs.groovy
@@ -1,0 +1,14 @@
+node('master') {
+    stage('Checkout') {
+        cleanWs()
+        checkout scm
+    }
+
+    stage('Seed') {
+        // https://issues.jenkins-ci.org/browse/JENKINS-44142
+        // --> Note: when using multiple Job DSL build steps in a single job, set this to "Delete" only for the last Job DSL build step. 
+        // Otherwise views may be deleted and re-created. See JENKINS-44142 for details.
+        jobDsl(targets: 'shared-library/jobDSL/folders.groovy', sandbox: false, removedJobAction: 'IGNORE')
+        jobDsl(targets: 'shared-library/jobDSL/*.groovy', sandbox: false, removedJobAction: 'DELETE')
+    }
+}

--- a/shared-library/pipeline.groovy
+++ b/shared-library/pipeline.groovy
@@ -23,12 +23,4 @@ node('master') {
         // disable csrf for easier jenkins api calls
         load('shared-library/config/groovy/csrf.groovy')
     }
-
-    stage('Seed') {
-        // https://issues.jenkins-ci.org/browse/JENKINS-44142
-        // --> Note: when using multiple Job DSL build steps in a single job, set this to "Delete" only for the last Job DSL build step. 
-        // Otherwise views may be deleted and re-created. See JENKINS-44142 for details.
-        jobDsl(targets: 'shared-library/jobDSL/folders.groovy', sandbox: false, removedJobAction: 'IGNORE')
-        jobDsl(targets: 'shared-library/jobDSL/*.groovy', sandbox: false, removedJobAction: 'DELETE')
-    }
 }


### PR DESCRIPTION
The usual Configure job does all the jenkins configuration steps.

The new Jobs job just create all the jenkins jobs based on the provided
jobDSL files.