### PR TITLE
Add github-branch-source plugin for multibranchPipelineJob

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -7,6 +7,7 @@ pipeline-model-definition
 git
 git-parameter
 github
+github-branch-source
 
 # add authorization matrix support
 matrix-auth


### PR DESCRIPTION
This plugin is used to define branch sources for multi branch
pipeline jobs within a jobDsl script.