### PR TITLE
Set api rate limit to throttle on over as the default

### DIFF
--- a/shared-library/config/casc-config/jenkins.yaml
+++ b/shared-library/config/casc-config/jenkins.yaml
@@ -27,6 +27,10 @@ security:
   sSHD:
     port: 6666
 
+unclassified:
+  gitHubConfiguration:
+    apiRateLimitChecker: ThrottleOnOver
+
 # unclassified:
 #   globalLibraries:
 #     libraries:


### PR DESCRIPTION
The multibranchPipelineJob using the github branch source plugin to
scan a github repository for all existing branches.

The default behaviour of the github branch source plugin is try
to optimise the exhaustion of the github api rate limit.

The default api rate limit for an public repository is around
60 request per hour. This prevention of api rate limit exhaustion leads
to failed builds or long build time for event the first time in the
hour.

Disable the prevention of api rate limiting exhaustion by setting the
follow configuration.

```
unclassified:
  gitHubConfiguration:
    apiRateLimitChecker: ThrottleOnOver
```